### PR TITLE
Version 2.0.1 - Correcting headers

### DIFF
--- a/arlulacore/auth.py
+++ b/arlulacore/auth.py
@@ -9,14 +9,14 @@ from .exception import ArlulaSessionError
 name = "arlulacore"
 
 # User agent setting
-sdk_version = "1.0.1"
+sdk_version = "2.0.1"
 py_version = sys.version.split(' ')[0]
 os_version = platform.platform()
 def_ua = "core-sdk " + \
     sdk_version + " python " + py_version + " OS " + os_version
 
 # Expected API version
-x_api_version = '2020-12'
+x_api_version = '2021-09'
 
 class Session:
     '''

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='arlulacore',
-    version='2.0.0',
+    version='2.0.1',
     author="Arlula",
     author_email="tech@arlula.com",
     description="A package to facilitate access to the Arlula Imagery Marketplace API",


### PR DESCRIPTION
This PR is a minor patch that fixes incorrect headers from the past version.
- it updates the user agent header to `2.0.1` 
- it updates the x_api_version string to `2021-09`