### PR TITLE
SearchRequest constructor res param type hint

### DIFF
--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -91,7 +91,7 @@ class SearchRequest(ArlulaObject):
     cloud: float
 
     def __init__(self, start: date,
-            res: typing.Optional[float],
+            res: float,
             cloud: typing.Optional[float] = None,
             end: typing.Optional[date] = None,
             lat: typing.Optional[float] = None,


### PR DESCRIPTION
From the API docs res is not optional, so it should not be marked as such.
Alternatively, if it is optional, then it should have a default value of `None`