### PR TITLE
Fix for executing SearchRequest with end as None - Take 2

### DIFF
--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -91,7 +91,7 @@ class SearchRequest(ArlulaObject):
     cloud: float
 
     def __init__(self, start: date,
-            res: typing.Optional[float],
+            res: float,
             cloud: typing.Optional[float] = None,
             end: typing.Optional[date] = None,
             lat: typing.Optional[float] = None,

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -164,7 +164,7 @@ class SearchRequest(ArlulaObject):
             "west": self.west, "supplier": self.supplier, "off-nadir": self.off_nadir}
 
         query_params = {k: v for k, v in param_dict.items()
-            if v is not None or v == "None"}
+            if v is not None and v != "None"}
 
         return query_params
 

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -91,7 +91,7 @@ class SearchRequest(ArlulaObject):
     cloud: float
 
     def __init__(self, start: date,
-            res: float,
+            res: typing.Optional[float],
             cloud: typing.Optional[float] = None,
             end: typing.Optional[date] = None,
             lat: typing.Optional[float] = None,
@@ -164,7 +164,7 @@ class SearchRequest(ArlulaObject):
             "west": self.west, "supplier": self.supplier, "off-nadir": self.off_nadir}
 
         query_params = {k: v for k, v in param_dict.items()
-            if v is not None or v == 0}
+            if v is not None or v == "None"}
 
         return query_params
 


### PR DESCRIPTION
If end is `None`, then it is converted to the string `"None"`, and thus not excluded as part of the dictionary comprehension.

Replaces the `or v == 0` check with `and v != "None"` as the former was unecessary (only None values would make it through `if v is not None`, and `None == 0` is always False)