### PR TITLE
3.0.3 - Arlula API 2023-01 and Code Quality Updates

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,6 +19,7 @@ jobs:
       TEST_API_ORDER_BUNDLE_KEY: ${{ secrets.TEST_API_ORDER_BUNDLE_KEY }}
       TEST_API_ORDER_ID: ${{ secrets.TEST_API_ORDER_ID }}
       TEST_API_RESOURCE_ID: ${{ secrets.TEST_API_RESOURCE_ID }}
+      TEST_API_TEAM_ID: ""
 
   deploy:
     needs: test

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -33,6 +33,16 @@ jobs:
           python-version: '3.x'
       - run: pip3 install -r requirements.txt
       - run: python3 -m unittest tests/test_setup.py
+        env:
+            API_KEY: ${{ secrets.TEST_API_KEY }}
+            API_SECRET: ${{ secrets.TEST_API_SECRET }}
+            API_ORDERING_ID: ${{ secrets.TEST_API_ORDERING_ID }}
+            API_ORDER_LICENSE_HREF: ${{ secrets.TEST_API_ORDER_LICENSE_HREF }}
+            API_ORDER_BUNDLE_KEY: ${{ secrets.TEST_API_ORDER_BUNDLE_KEY }}
+            API_HOST: ${{ secrets.TEST_API_HOST }}
+            API_ORDER_ID: ${{ secrets.TEST_API_ORDER_ID }}
+            API_RESOURCE_ID: ${{ secrets.TEST_API_RESOURCE_ID }}
+            API_TEAM_ID: ""
       - run: python3 -m unittest tests/test_archive.py tests/test_orders.py tests/test_price.py tests/test_rfc3339.py
         env:
           API_KEY: ${{ secrets.TEST_API_KEY }}
@@ -43,3 +53,4 @@ jobs:
           API_HOST: ${{ secrets.TEST_API_HOST }}
           API_ORDER_ID: ${{ secrets.TEST_API_ORDER_ID }}
           API_RESOURCE_ID: ${{ secrets.TEST_API_RESOURCE_ID }}
+          API_TEAM_ID: ""

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           python-version: '3.x'
       - run: pip3 install -r requirements.txt
-      - run: python3 -m unittest tests/test_archive.py tests/test_orders.py tests/test_price.py tests/test_rfc3339.py tests/test_setup.py
+      - run: python3 -m unittest tests/test_setup.py
+      - run: python3 -m unittest tests/test_archive.py tests/test_orders.py tests/test_price.py tests/test_rfc3339.py
         env:
           API_KEY: ${{ secrets.TEST_API_KEY }}
           API_SECRET: ${{ secrets.TEST_API_SECRET }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: '3.x'
       - run: pip3 install -r requirements.txt
-      - run: python3 -m unittest tests/test_archive.py tests/test_orders.py tests/test_rfc3339.py tests/test_price.py
+      - run: python3 -m unittest tests/test_archive.py tests/test_orders.py tests/test_price.py tests/test_rfc3339.py tests/test_setup.py
         env:
           API_KEY: ${{ secrets.TEST_API_KEY }}
           API_SECRET: ${{ secrets.TEST_API_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+*.env
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,133 @@
-test
-dist
-build
-__pycache__
-*.cpython
-arlulaapi.egg-info
-test.py
-credentials.json
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
 .env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Coverage reports
+coverage.lcov
+lcov.info

--- a/arlulacore/__init__.py
+++ b/arlulacore/__init__.py
@@ -1,5 +1,5 @@
 from .auth import (
-    Session
+    Session,
 )
 
 from .archive import (
@@ -13,26 +13,27 @@ from .archive import (
     SearchResponse,
     SearchRequest,
     OrderRequest,
-    ArchiveAPI
+    ArchiveAPI,
 )
 from .orders import (
     OrderResult,
-    OrdersAPI
+    OrdersAPI,
+    DetailedOrderResult,
 )
 
 from .arlula import (
-    ArlulaAPI
+    ArlulaAPI,
 )
 
 from .common import (
-    ArlulaObject
+    ArlulaObject,
 )
 
 from .exception import (
-    ArlulaSessionError
+    ArlulaSessionError,
 )
 
 from .util import (
     parse_rfc3339,
-    calculate_price
+    calculate_price,
 )

--- a/arlulacore/__init__.py
+++ b/arlulacore/__init__.py
@@ -31,6 +31,7 @@ from .common import (
 
 from .exception import (
     ArlulaSessionError,
+    ArlulaAPIException,
 )
 
 from .util import (

--- a/arlulacore/__init__.py
+++ b/arlulacore/__init__.py
@@ -14,6 +14,7 @@ from .archive import (
     SearchRequest,
     OrderRequest,
     ArchiveAPI,
+    Polygon,
 )
 from .orders import (
     OrderResult,

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -456,7 +456,7 @@ class OrderRequest(ArlulaObject):
             "bundleKey": self.bundle_key,
             "webhooks": self.webhooks,
             "emails": self.emails,
-            "team": self.team,
+            "team": None if self.team == "" else self.team,
         })
 
 

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -364,8 +364,8 @@ class OrderRequest(ArlulaObject):
     def valid(self) -> bool:
         return self.id != None and self.eula != None and self.bundle_key != None
 
-    def dumps(self):
-        return json.dumps({
+    def dict(self):
+        return remove_none({
             "id": self.id,
             "eula": self.eula,
             "bundleKey": self.bundle_key,
@@ -414,7 +414,7 @@ class ArchiveAPI:
         response = requests.request(
             "POST",
             url,
-            data=request.dumps(),
+            data=json.dumps(request.dict()),
             headers=self.session.header)
 
         if response.status_code != 200:

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import string
 import typing
@@ -9,43 +10,79 @@ from .common import ArlulaObject
 from .auth import Session
 from .exception import ArlulaSessionError
 from .orders import DetailedOrderResult
-from .util import parse_rfc3339, calculate_price
+from .util import parse_rfc3339, calculate_price, remove_none
 
-
-@dataclass
 class CenterPoint(ArlulaObject):
+    data: dict
     long: float
     lat: float
 
-@dataclass
+    def __init__(self, data):
+        self.data = data
+        self.long = data["long"]
+        self.lat = data["lat"]
+
+    def dict(self) -> dict:
+        return self.data
+
 class Percent(ArlulaObject):
+    data: dict
     scene: float
     search: float
 
-@dataclass
+    def __init__(self, data):
+        self.data = data
+        self.scene = data["scene"]
+        self.search = data["search"]
+
+    def dict(self) -> dict:
+        return self.data
+
 class Overlap(ArlulaObject):
+    data: dict
     area: float
     percent: Percent
     polygon: typing.List[typing.List[typing.List[float]]]
 
+    def __init__(self, data):
+        self.data = data
+        self.area = data["area"]
+        self.percent = data["percent"]
+        self.polygon = data["polygon"]
+
+    def dict(self) -> dict:
+        return self.data
+
 class License(ArlulaObject):
+    data: dict
     name: str
     href: str
     loading_percent: float
     loading_amount: int
 
     def __init__(self, data):
+        self.data = data
         self.name = data["name"]
         self.href = data["href"]
         self.loading_percent = data["loadingPercent"]
         self.loading_amount = data["loadingAmount"]
 
-@dataclass
+    def dict(self) -> dict:
+        return self.data
+
 class Band(ArlulaObject):
+    data: dict
     name: str
     id: str
     min: float
     max: float
+
+    def __init__(self, data):
+        self.data = data
+        self.name = data["name"]
+        self.id = data["id"]
+        self.min = data["min"]
+        self.max = data["max"]
 
     def centre(self) -> float:
         '''
@@ -59,14 +96,28 @@ class Band(ArlulaObject):
         '''
         return self.max - self.min
 
-@dataclass
+    def dict(self) -> dict:
+        return self.data
+
 class Bundle(ArlulaObject):
+    data: dict
     name: str
     key: str
     bands: typing.List[str]
     price: int
 
+    def __init__(self, data):
+        self.data = data
+        self.name = data["name"]
+        self.key = data["key"]
+        self.bands = data["bands"]
+        self.price = data["price"]
+
+    def dict(self) -> dict:
+        return self.data
+
 class SearchResult(ArlulaObject):
+    data: dict
     scene_id: str
     supplier: str
     platform: str
@@ -87,6 +138,7 @@ class SearchResult(ArlulaObject):
     annotations: typing.List[str]
 
     def __init__(self, data):
+        self.data = data
         self.scene_id = data["sceneID"]
         self.supplier = data["supplier"]
         self.platform = data["platform"]
@@ -141,16 +193,22 @@ class SearchResult(ArlulaObject):
 
         return calculate_price(bundle.price, license.loading_percent, license.loading_amount)
 
+    def dict(self) -> dict:
+        return self.data
+
 class SearchResponse(ArlulaObject):
+    data: dict
     state: string
     errors: typing.List[str]
     warnings: typing.List[str]
     results: typing.List[SearchResult]
 
     def __init__(self, data):
+        self.data = data
         self.state = ""
         self.errors = []
         self.warnings = []
+        self.results = []
 
         if "state" in data:
             self.state = data["state"]
@@ -161,7 +219,10 @@ class SearchResponse(ArlulaObject):
         if "results" in data:
             self.results = [SearchResult(e) for e in data["results"]]
 
-class SearchRequest(ArlulaObject):
+    def dict(self) -> dict:
+        return self.data
+
+class SearchRequest():
     start: date
     gsd: float
     end: date
@@ -264,7 +325,7 @@ class SearchRequest(ArlulaObject):
 
         return query_params
 
-class OrderRequest:
+class OrderRequest(ArlulaObject):
 
     id: str
     eula: str

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -12,6 +12,7 @@ from .auth import Session
 from .exception import ArlulaAPIException
 from .orders import DetailedOrderResult
 from .util import parse_rfc3339, calculate_price, remove_none, simple_indent
+
 Polygon = typing.Union[typing.List[typing.List[typing.List[float]]], str]
 
 class CenterPoint(ArlulaObject):
@@ -396,11 +397,11 @@ class SearchRequest():
             "lat": self.lat, "long": self.long,
             "north": self.north, "south": self.south, "east": self.east, 
             "west": self.west, "supplier": self.supplier, "off-nadir": self.off_nadir,
-            "polygon": self.polygon}
+            "polygon": json.dumps(self.polygon) if isinstance(self.polygon, list) else self.polygon}
 
         query_params = {k: v for k, v in param_dict.items()
             if v is not None}
-
+        print(query_params)
         return remove_none(query_params)
 
 class OrderRequest(ArlulaObject):

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -406,13 +406,15 @@ class OrderRequest(ArlulaObject):
             id: str,
             eula: str,
             bundle_key: str,
-            webhooks: typing.List[str] = [],
-            emails: typing.List[str] = []):
+            webhooks: typing.Optional[typing.List[str]] = [],
+            emails: typing.Optional[typing.List[str]] = [],
+            team: typing.Optional[str] = None):
         self.id = id
         self.eula = eula
         self.bundle_key = bundle_key
         self.webhooks = webhooks
         self.emails = emails
+        self.team = team
     
     def add_webhook(self, webhook: str) -> "OrderRequest":
         self.webhooks.append(webhook)
@@ -430,6 +432,10 @@ class OrderRequest(ArlulaObject):
         self.emails = emails
         return self
 
+    def set_team(self, team: str) -> "OrderRequest":
+        self.team = team
+        return self
+
     def valid(self) -> bool:
         return self.id != None and self.eula != None and self.bundle_key != None
 
@@ -439,7 +445,8 @@ class OrderRequest(ArlulaObject):
             "eula": self.eula,
             "bundleKey": self.bundle_key,
             "webhooks": self.webhooks,
-            "emails": self.emails
+            "emails": self.emails,
+            "team": self.team,
         })
 
 

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -401,7 +401,7 @@ class SearchRequest():
 
         query_params = {k: v for k, v in param_dict.items()
             if v is not None}
-        print(query_params)
+
         return remove_none(query_params)
 
 class OrderRequest(ArlulaObject):

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from .common import ArlulaObject
 from .auth import Session
-from .exception import ArlulaSessionError
+from .exception import ArlulaAPIException, ArlulaSessionError
 from .orders import DetailedOrderResult
-from .util import parse_rfc3339, calculate_price, remove_none
+from .util import get_error_message, parse_rfc3339, calculate_price, remove_none
 
 class CenterPoint(ArlulaObject):
     data: dict
@@ -398,7 +398,7 @@ class ArchiveAPI:
             headers=self.session.header,
             params=request.dict())
         if response.status_code != 200:
-            raise ArlulaSessionError(response.text)
+            raise ArlulaAPIException(response)
         else:
             resp_data = json.loads(response.text)
             # Construct an instance of `SearchResponse`
@@ -418,6 +418,6 @@ class ArchiveAPI:
             headers=self.session.header)
 
         if response.status_code != 200:
-            raise ArlulaSessionError(response.text)
+            raise ArlulaAPIException(response)
         else:
             return DetailedOrderResult(json.loads(response.text))

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -296,7 +296,6 @@ class OrderRequest:
             "id": self.id,
             "eula": self.eula,
             "bundleKey": self.bundle_key,
-            "seats": 1, # For legacy support
             "webhooks": self.webhooks,
             "emails": self.emails
         })

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -150,10 +150,10 @@ class SearchResult(ArlulaObject):
         self.gsd = data["gsd"]
 
         self.bands = []
-        self.bands += [Band(**b) for b in data["bands"]]
+        self.bands += [Band(b) for b in data["bands"]]
 
         self.area = data["area"]
-        self.center = CenterPoint(**data["center"])
+        self.center = CenterPoint(data["center"])
         self.bounding = data["bounding"]
         self.overlap = data["overlap"]
         self.fulfillment_time = data["fulfillmentTime"]
@@ -161,7 +161,7 @@ class SearchResult(ArlulaObject):
         self.ordering_id = data["orderingID"]
             
         self.bundles = []
-        self.bundles += [Bundle(**b) for b in data["bundles"]]
+        self.bundles += [Bundle(b) for b in data["bundles"]]
         self.license = []
         self.license += [License(l) for l in data["license"]]
 
@@ -323,7 +323,7 @@ class SearchRequest():
         query_params = {k: v for k, v in param_dict.items()
             if v is not None}
 
-        return query_params
+        return remove_none(query_params)
 
 class OrderRequest(ArlulaObject):
 

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -329,10 +329,6 @@ class ArchiveAPI:
             raise ArlulaSessionError(response.text)
         else:
             resp_data = json.loads(response.text)
-            # Break result into a list of objects (Legacy)
-            if (type(resp_data) == list):
-                lst = [SearchResult(x) for x in resp_data]
-                return SearchResponse(lst)
             # Construct an instance of `SearchResponse`
             return SearchResponse(resp_data)
 

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -27,7 +27,7 @@ class CenterPoint(ArlulaObject):
         return self.data
 
     def __str__(self) -> str:
-        return f"Center: {self.long} E/W, {self.lat} N/S"
+        return f"Center: {self.long} {'E' if self.long < 0 else 'W'}, {self.lat} {'S' if self.lat < 0 else 'N'}"
 
 class Percent(ArlulaObject):
     data: dict
@@ -43,7 +43,7 @@ class Percent(ArlulaObject):
         return self.data
     
     def __str__(self) -> str:
-        return f"Overlap: {self.scene}% of scene, {self.search}% of search"
+        return f"Coverage: {self.scene}% of scene, {self.search}% of search"
 
 class Overlap(ArlulaObject):
     data: dict
@@ -62,6 +62,7 @@ class Overlap(ArlulaObject):
     
     def __str__(self) -> str:
         return simple_indent(
+        f"Overlap:\n"\
         f"Area: {self.area} sqkm\n"\
         f"{str(self.percent)}\n"\
         f"Geometry: {self.polygon}", 0, 2)
@@ -85,8 +86,8 @@ class License(ArlulaObject):
 
     def __str__(self) -> str:
         return simple_indent(
+        f"License ({self.href}):\n"\
         f"Name: {self.name}\n"\
-        f"Href: {self.href}\n"\
         f"Loading: {self.loading_amount} US Cents + {self.loading_percent}%\n", 0, 2)
 
 class Band(ArlulaObject):
@@ -120,8 +121,8 @@ class Band(ArlulaObject):
 
     def __str__(self) -> str:
         return simple_indent(
-            f"Band ({self.name})\n"\
-            f"ID: {self.id}\n"\
+            f"Band ({self.id}):\n"\
+            f"Name: {self.name}\n"\
             f"Bandwidth: {self.min}nm - {self.max}nm\n", 0, 2)
 
 class Bundle(ArlulaObject):
@@ -142,10 +143,11 @@ class Bundle(ArlulaObject):
         return self.data
 
     def __str__(self) -> str:
+        bands = 'all' if len(self.bands) == 0 else '\n'.join(self.bands)
         return simple_indent(
+            f"Bundle ({self.key}):\n"\
             f"Name: {self.name}\n"\
-            f"Key: {self.key}\n"\
-            f"Bands: {self.bands}\n"\
+            f"Bands: {bands}\n"\
             f"Price: {self.price} US Cents\n", 0, 2)
 
 class SearchResult(ArlulaObject):
@@ -230,32 +232,31 @@ class SearchResult(ArlulaObject):
 
     def __str__(self) -> str:
 
-        bundles = ""
-        for b in self.bundles:
-            bundles += simple_indent(str(b), 4, 4)
+        bundles = simple_indent(''.join([str(b) for b in self.bundles]), 2, 2)
+        bands = simple_indent(''.join([str(b) for b in self.bands]), 2, 2)
+        license = simple_indent(''.join([str(l) for l in self.license]), 2, 2)
         return simple_indent(
-            f"Result:\n"\
+            f"Result ({self.ordering_id}):\n"\
             f"Scene ID: {self.scene_id}\n"\
             f"Supplier: {self.supplier}\n"\
             f"Platform: {self.platform}\n"\
             f"Capture Date: {self.date.strftime('%Y-%m-%d')}\n"\
             f"Thumbnail URL: {self.thumbnail}\n"\
-            f"Cloud Coverage: {self.cloud*100}%\n"\
+            f"Cloud Coverage: {self.cloud}%\n"\
             f"Off Nadir: {self.off_nadir} degrees\n"\
             f"Ground Sample Distance: {self.gsd} m\n"\
-            f"Bands:\n"\
-            f"{simple_indent(str(self.bands[0]), 2, 2)}"
+            f"Fulfillment Time: {self.fulfillment_time}\n"\
             f"Area: {self.area} sqkm\n"\
             f"{str(self.center)}\n"\
             f"Bounding: {self.bounding}\n"\
             f"{str(self.overlap)}"\
-            f"Fulfillment Time: {self.fulfillment_time}\n"\
-            f"Ordering ID: {self.ordering_id}\n"\
+            f"Bands:\n"\
+            f"{bands}"
             f"Bundles: \n"\
-            f"{simple_indent(str(self.bundles[0]), 2, 2)}"
+            f"{bundles}"
             f"License: \n"\
-            f"{simple_indent(str(self.license[0]), 2, 2)}"
-            f"Annotations {self.annotations}\n", 0, 2)
+            f"{license}"
+            f"Annotations: {', '.join(self.annotations)}\n", 0, 2)
 
 class SearchResponse(ArlulaObject):
     data: dict

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from .common import ArlulaObject
 from .auth import Session
-from .exception import ArlulaAPIException, ArlulaSessionError
+from .exception import ArlulaAPIException
 from .orders import DetailedOrderResult
-from .util import get_error_message, parse_rfc3339, calculate_price, remove_none
+from .util import parse_rfc3339, calculate_price, remove_none
 
 class CenterPoint(ArlulaObject):
     data: dict

--- a/arlulacore/archive.py
+++ b/arlulacore/archive.py
@@ -240,6 +240,15 @@ class SearchRequest(ArlulaObject):
     def set_maximum_cloud_cover(self, cloud: float) -> "SearchRequest":
         self.cloud = cloud
         return self
+
+    def valid_point_of_interest(self) -> bool:
+        return self.lat != None and self.long != None
+
+    def valid_area_of_interest(self) -> bool:
+        return self.north != None and self.south != None and self.east != None and self.west != None
+    
+    def valid(self) -> bool:
+        return (self.valid_area_of_interest() or self.valid_point_of_interest) and self.start != None and self.gsd != None
     
     def dict(self):
         param_dict = {
@@ -290,6 +299,9 @@ class OrderRequest:
     def set_emails(self, emails: typing.List[str]) -> "OrderRequest":
         self.emails = emails
         return self
+
+    def valid(self) -> bool:
+        return self.id != None and self.eula != None and self.bundle_key != None
 
     def dumps(self):
         return json.dumps({

--- a/arlulacore/auth.py
+++ b/arlulacore/auth.py
@@ -40,6 +40,8 @@ class Session:
             'User-Agent': user_agent,
             'X-API-Version': x_api_version
         }
+        if url is None:
+            url = "https://api.arlula.com"
         self.baseURL = url
         if test:
             self.validate_creds()

--- a/arlulacore/auth.py
+++ b/arlulacore/auth.py
@@ -10,7 +10,7 @@ from .exception import ArlulaSessionError
 name = "arlulacore"
 
 # User agent setting
-sdk_version = "3.0.2"
+sdk_version = "3.0.3"
 py_version = sys.version.split(' ')[0]
 os_version = platform.platform()
 def_ua = "core-sdk " + \

--- a/arlulacore/auth.py
+++ b/arlulacore/auth.py
@@ -28,7 +28,8 @@ class Session:
                  key: str,
                  secret: str,
                  user_agent: typing.Optional[str] = def_ua,
-                 url: typing.Optional[str] = "https://api.arlula.com"
+                 url: typing.Optional[str] = "https://api.arlula.com",
+                 test: typing.Optional[bool] = True,
                  ):
         # Encode the key and secret
         def atob(x): return x.encode('utf-8')
@@ -40,7 +41,8 @@ class Session:
             'X-API-Version': x_api_version
         }
         self.baseURL = url
-        self.validate_creds()
+        if test:
+            self.validate_creds()
 
     # Check the credentials are valid
     def validate_creds(self):

--- a/arlulacore/auth.py
+++ b/arlulacore/auth.py
@@ -17,7 +17,7 @@ def_ua = "core-sdk " + \
     sdk_version + " python " + py_version + " OS " + os_version
 
 # Expected API version
-x_api_version = '2021-09'
+x_api_version = '2023-01'
 
 class Session:
     '''

--- a/arlulacore/common.py
+++ b/arlulacore/common.py
@@ -1,3 +1,18 @@
-class ArlulaObject:
+import abc
+import json
+
+class ArlulaObject(abc.ABC):
     def __repr__(self):
         return str(['{}: {}'.format(attr, value) for attr, value in self.__dict__.items()])[1:-1].replace('\'', '')
+
+    @abc.abstractmethod
+    def dict(self):
+        pass
+
+    def format(self, format: str) -> str:
+        if format == "json":
+            return json.dumps(self.dict())
+        if format == "text":
+            return self
+        if format == "table":
+            return self

--- a/arlulacore/common.py
+++ b/arlulacore/common.py
@@ -13,6 +13,8 @@ class ArlulaObject(abc.ABC):
         if format == "json":
             return json.dumps(self.dict())
         if format == "text":
-            return self
+            return str(self)
+        if format == "pretty-json":
+            return json.dumps(self.dict(), indent=1)
         if format == "table":
-            return self
+            return str(self)

--- a/arlulacore/exception.py
+++ b/arlulacore/exception.py
@@ -1,3 +1,5 @@
+import requests
+
 '''
     Custom Exception Class
 '''
@@ -5,6 +7,13 @@
 class ArlulaSessionError(Exception):
     def __init__(self, value):
         self.value = value
+
+    def __str__(self):
+        return self.value
+
+class ArlulaAPIException(Exception):
+    def __init__(self, response: requests.Response):
+        self.value = f"{response.status_code}: {response.text}"
 
     def __str__(self):
         return self.value

--- a/arlulacore/orders.py
+++ b/arlulacore/orders.py
@@ -129,9 +129,10 @@ class DetailedOrderResult(ArlulaObject):
         self.total = data["total"]
         self.type = data["type"]
         self.expiration = data["expiration"]
-        self.resources = [Resource(x) for x in data["resources"]]
+        self.resources = [Resource(x) for x in data["resources"]] if data["resources"] is not None else []
     
     def __str__(self) -> dict:
+        resources = simple_indent(''.join([str(r) for r in self.resources]), 2, 2)
         text = simple_indent(
             f"Detailed Order ({self.id}):\n"\
             # f"Created At: {self.created_at}\n"\
@@ -143,9 +144,8 @@ class DetailedOrderResult(ArlulaObject):
             f"Total: {self.total}\n"\
             f"Type: {self.type}\n"\
             f"Expiration: {self.expiration}\n"\
-            f"Resources:\n", 0, 2)
-        for r in self.resources:
-            text += simple_indent(str(r), 4, 4)   
+            f"Resources:\n"\
+            f"{resources}", 0, 2)
         return text
 
     def dict(self) -> dict:

--- a/arlulacore/orders.py
+++ b/arlulacore/orders.py
@@ -7,11 +7,12 @@ import typing
 import json
 import requests
 import sys
+import textwrap
 
 from .auth import Session
 from .exception import ArlulaAPIException, ArlulaSessionError
 from .common import ArlulaObject
-from .util import parse_rfc3339
+from .util import parse_rfc3339, simple_indent
 
 class Resource(ArlulaObject):
     data: dict
@@ -38,6 +39,20 @@ class Resource(ArlulaObject):
         self.roles = data["roles"]
         self.size = data["size"]
         self.checksum = data["checksum"]
+
+    def __str__(self) -> str:
+        text = simple_indent(
+            f"Resource {self.id}\n"\
+            f"Created At: {self.created_at.isoformat()}\n"\
+            f"Updated At: {self.updated_at.isoformat()}\n"\
+            f"Order ID: {self.order}\n"\
+            f"Name: {self.name}\n"\
+            f"Type: {self.type}\n"\
+            f"Format: {self.format}\n"\
+            f"Roles: {self.roles}\n"\
+            f"Size: {self.size} Bytes\n"\
+            f"Checksum: {self.checksum}\n", 0, 2)
+        return text
 
     def dict(self):
         return self.data
@@ -67,6 +82,20 @@ class OrderResult(ArlulaObject):
         self.total = data["total"]
         self.type = data["type"]
         self.expiration = data["expiration"]
+
+    def __str__(self) -> str:
+        text = simple_indent(
+            f"Order ({self.id})\n"\
+            f"Created At: {self.created_at}\n"\
+            f"Updated At: {self.updated_at}\n"\
+            f"Supplier: {self.supplier}\n"\
+            f"Ordering ID: {self.ordering_id}\n"\
+            f"Scene ID: {self.scene_id}\n"\
+            f"Status: {self.status}\n"\
+            f"Total: {self.total}\n"\
+            f"Type: {self.type}\n"\
+            f"Expiration: {self.expiration}\n", 0, 2)
+        return text
 
     def dict(self) -> dict:
         return self.data
@@ -98,6 +127,22 @@ class DetailedOrderResult(ArlulaObject):
         self.type = data["type"]
         self.expiration = data["expiration"]
         self.resources = [Resource(x) for x in data["resources"]]
+    
+    def __str__(self) -> dict:
+        text = simple_indent(
+            f"Detailed Order ({self.id})\n"\
+            f"Created At: {self.created_at}\n"\
+            f"Updated At: {self.updated_at}\n"\
+            f"Supplier: {self.supplier}\n"\
+            f"Ordering ID: {self.ordering_id}\n"\
+            f"Scene ID: {self.scene_id}\n"\
+            f"Status: {self.status}\n"\
+            f"Total: {self.total}\n"\
+            f"Type: {self.type}\n"\
+            f"Expiration: {self.expiration}\n", 0, 2)
+        for r in self.resources:
+            text += simple_indent(str(r), 4, 4)   
+        return text
 
     def dict(self) -> dict:
         return self.data

--- a/arlulacore/orders.py
+++ b/arlulacore/orders.py
@@ -45,14 +45,14 @@ class Resource(ArlulaObject):
 
     def __str__(self) -> str:
         text = simple_indent(
-            f"Resource {self.id}\n"\
+            f"Resource ({self.id})\n"\
             # f"Created At: {self.created_at.isoformat()}\n"\
             # f"Updated At: {self.updated_at.isoformat()}\n"\
-            f"Order ID: {self.order}\n"\
+            # f"Order ID: {self.order}\n"\
             f"Name: {self.name}\n"\
             f"Type: {self.type}\n"\
             f"Format: {self.format}\n"\
-            f"Roles: {self.roles}\n"\
+            f"Roles: {', '.join(self.roles)}\n"\
             f"Size: {self.size} Bytes\n"\
             f"Checksum: {self.checksum}\n", 0, 2)
         return text

--- a/arlulacore/orders.py
+++ b/arlulacore/orders.py
@@ -45,7 +45,7 @@ class Resource(ArlulaObject):
 
     def __str__(self) -> str:
         text = simple_indent(
-            f"Resource ({self.id})\n"\
+            f"Resource ({self.id}):\n"\
             # f"Created At: {self.created_at.isoformat()}\n"\
             # f"Updated At: {self.updated_at.isoformat()}\n"\
             # f"Order ID: {self.order}\n"\
@@ -88,7 +88,7 @@ class OrderResult(ArlulaObject):
 
     def __str__(self) -> str:
         text = simple_indent(
-            f"Order ({self.id})\n"\
+            f"Order ({self.id}):\n"\
             # f"Created At: {self.created_at}\n"\
             # f"Updated At: {self.updated_at}\n"\
             f"Supplier: {self.supplier}\n"\
@@ -133,7 +133,7 @@ class DetailedOrderResult(ArlulaObject):
     
     def __str__(self) -> dict:
         text = simple_indent(
-            f"Detailed Order ({self.id})\n"\
+            f"Detailed Order ({self.id}):\n"\
             # f"Created At: {self.created_at}\n"\
             # f"Updated At: {self.updated_at}\n"\
             f"Supplier: {self.supplier}\n"\
@@ -142,7 +142,8 @@ class DetailedOrderResult(ArlulaObject):
             f"Status: {self.status}\n"\
             f"Total: {self.total}\n"\
             f"Type: {self.type}\n"\
-            f"Expiration: {self.expiration}\n", 0, 2)
+            f"Expiration: {self.expiration}\n"\
+            f"Resources:\n", 0, 2)
         for r in self.resources:
             text += simple_indent(str(r), 4, 4)   
         return text

--- a/arlulacore/orders.py
+++ b/arlulacore/orders.py
@@ -9,7 +9,7 @@ import requests
 import sys
 
 from .auth import Session
-from .exception import ArlulaSessionError
+from .exception import ArlulaAPIException, ArlulaSessionError
 from .common import ArlulaObject
 from .util import parse_rfc3339
 
@@ -129,7 +129,7 @@ class OrdersAPI:
             params=querystring)
 
         if response.status_code != 200:
-            raise ArlulaSessionError(response.text)
+            raise ArlulaAPIException(response)
         else:
             return DetailedOrderResult(json.loads(response.text))
 
@@ -146,7 +146,7 @@ class OrdersAPI:
             headers=self.session.header)
 
         if response.status_code != 200:
-            raise ArlulaSessionError(response.text)
+            raise ArlulaAPIException(response)
         else:
             return [OrderResult(r) for r in json.loads(response.text)]
 
@@ -183,7 +183,7 @@ class OrdersAPI:
         total = response.headers.get('content-length')
 
         if response.status_code != 200:
-            raise ArlulaSessionError(response.text)
+            raise ArlulaAPIException(response)
 
         if total is None:
             f.write(response.content)

--- a/arlulacore/orders.py
+++ b/arlulacore/orders.py
@@ -14,6 +14,7 @@ from .common import ArlulaObject
 from .util import parse_rfc3339
 
 class Resource(ArlulaObject):
+    data: dict
     id: str
     created_at: datetime
     updated_at: datetime
@@ -26,6 +27,7 @@ class Resource(ArlulaObject):
     checksum: str
 
     def __init__(self, data):
+        self.data = data
         self.id = data["id"]
         self.created_at = parse_rfc3339(data["createdAt"])
         self.updated_at = parse_rfc3339(data["updatedAt"])
@@ -37,7 +39,11 @@ class Resource(ArlulaObject):
         self.size = data["size"]
         self.checksum = data["checksum"]
 
+    def dict(self):
+        return self.data
+
 class OrderResult(ArlulaObject):
+    data: dict
     id: str
     created_at: datetime
     updated_at: datetime
@@ -50,6 +56,7 @@ class OrderResult(ArlulaObject):
     expiration: typing.Optional[str]
 
     def __init__(self, data):
+        self.data = data
         self.id = data["id"]
         self.created_at = parse_rfc3339(data["createdAt"])
         self.updated_at = parse_rfc3339(data["updatedAt"])
@@ -61,7 +68,11 @@ class OrderResult(ArlulaObject):
         self.type = data["type"]
         self.expiration = data["expiration"]
 
+    def dict(self) -> dict:
+        return self.data
+
 class DetailedOrderResult(ArlulaObject):
+    data: dict
     id: str
     created_at: datetime
     updated_at: datetime
@@ -75,6 +86,7 @@ class DetailedOrderResult(ArlulaObject):
     resources: typing.List[Resource]
 
     def __init__(self, data):
+        self.data = data
         self.id = data["id"]
         self.created_at = parse_rfc3339(data["createdAt"])
         self.updated_at = parse_rfc3339(data["updatedAt"])
@@ -86,6 +98,9 @@ class DetailedOrderResult(ArlulaObject):
         self.type = data["type"]
         self.expiration = data["expiration"]
         self.resources = [Resource(x) for x in data["resources"]]
+
+    def dict(self) -> dict:
+        return self.data
 
 class OrdersAPI:
     '''

--- a/arlulacore/util.py
+++ b/arlulacore/util.py
@@ -13,6 +13,17 @@ def remove_none(d: dict) -> dict:
 def get_error(resp: requests.Response):
     return ArlulaSessionError(f"{resp.status_code}: {resp.text}")
 
+def simple_indent(s: str, first_amount: int, following_amount: int) -> str:
+    lines = s.splitlines()
+    out = [""]*len(lines)
+
+    for i, l in enumerate(lines):
+        if i == 0:
+            out[i] = first_amount*' ' + l
+        else:
+            out[i] = following_amount*' ' + l
+    return '\n'.join(out) + '\n'
+
 def parse_rfc3339(dt_str: str) -> datetime:
     try:
         result = re.search(__date_rx__, dt_str)

--- a/arlulacore/util.py
+++ b/arlulacore/util.py
@@ -4,6 +4,9 @@ from datetime import datetime, timezone, timedelta
 
 __date_rx__ = re.compile(r"^(?P<year>\d{4})-(?P<month>\d\d)-(?P<day>\d\d)[Tt](?P<hour>\d\d):(?P<minute>\d\d):(?P<second>\d\d)(?:\.(?P<sec_frac>\d+))?(?P<offset>(?:[zZ]|(?P<offset_sign>[+-])(?P<offset_hour>\d{2}):(?P<offset_minute>\d{2})))$")
 
+def remove_none(d: dict) -> dict:
+    return {k: v for k, v in d.items() if v is not None}
+
 def parse_rfc3339(dt_str: str) -> datetime:
     try:
         result = re.search(__date_rx__, dt_str)

--- a/arlulacore/util.py
+++ b/arlulacore/util.py
@@ -1,11 +1,17 @@
 import math
 import re
+import requests
+
 from datetime import datetime, timezone, timedelta
+from arlulacore.exception import ArlulaSessionError
 
 __date_rx__ = re.compile(r"^(?P<year>\d{4})-(?P<month>\d\d)-(?P<day>\d\d)[Tt](?P<hour>\d\d):(?P<minute>\d\d):(?P<second>\d\d)(?:\.(?P<sec_frac>\d+))?(?P<offset>(?:[zZ]|(?P<offset_sign>[+-])(?P<offset_hour>\d{2}):(?P<offset_minute>\d{2})))$")
 
 def remove_none(d: dict) -> dict:
     return {k: v for k, v in d.items() if v is not None}
+
+def get_error(resp: requests.Response):
+    return ArlulaSessionError(f"{resp.status_code}: {resp.text}")
 
 def parse_rfc3339(dt_str: str) -> datetime:
     try:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='arlulacore',
-    version='3.0.2',
+    version='3.0.3',
     author="Arlula",
     author_email="tech@arlula.com",
     description="A package to facilitate access to the Arlula Imagery Marketplace API",

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -108,7 +108,6 @@ class TestOrderRequest(unittest.TestCase):
                 "id": "id",
                 "eula": "eula",
                 "bundleKey": "bundle_key",
-                "seats": 1,
                 "webhooks": [],
                 "emails": [],
             })
@@ -119,7 +118,6 @@ class TestOrderRequest(unittest.TestCase):
                 "id": "id",
                 "eula": "eula",
                 "bundleKey": "bundle_key",
-                "seats": 1,
                 "webhooks": ["https://test1.com", "https://test2.com"],
                 "emails": ["test1@gmail.com", "test2@gmail.com"],
             })
@@ -133,7 +131,6 @@ class TestOrderRequest(unittest.TestCase):
                 "id": "id",
                 "eula": "eula",
                 "bundleKey": "bundle_key",
-                "seats": 1,
                 "webhooks": ["https://test1.com", "https://test2.com"],
                 "emails": ["test1@gmail.com", "test2@gmail.com"],
             })

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -103,7 +103,7 @@ class TestOrderRequest(unittest.TestCase):
 
     def test_dumps(self):
         
-        self.assertEqual(arlulacore.OrderRequest("id", "eula", "bundle_key").dumps(), 
+        self.assertEqual(json.dumps(arlulacore.OrderRequest("id", "eula", "bundle_key").dict()), 
             json.dumps({
                 "id": "id",
                 "eula": "eula",
@@ -113,7 +113,7 @@ class TestOrderRequest(unittest.TestCase):
             })
         )
         
-        self.assertEqual(arlulacore.OrderRequest("id", "eula", "bundle_key", ["https://test1.com", "https://test2.com"], ["test1@gmail.com", "test2@gmail.com"]).dumps(),
+        self.assertEqual(json.dumps(arlulacore.OrderRequest("id", "eula", "bundle_key", ["https://test1.com", "https://test2.com"], ["test1@gmail.com", "test2@gmail.com"]).dict()),
             json.dumps({
                 "id": "id",
                 "eula": "eula",
@@ -123,10 +123,10 @@ class TestOrderRequest(unittest.TestCase):
             })
         )
 
-        self.assertEqual(arlulacore.OrderRequest("id", "eula", "bundle_key", ["https://test1.com"], ["test1@gmail.com"])
+        self.assertEqual(json.dumps(arlulacore.OrderRequest("id", "eula", "bundle_key", ["https://test1.com"], ["test1@gmail.com"])
             .add_email("test2@gmail.com")
             .add_webhook("https://test2.com")
-            .dumps(),
+            .dict()),
             json.dumps({
                 "id": "id",
                 "eula": "eula",
@@ -141,4 +141,4 @@ class TestOrderRequest(unittest.TestCase):
         # This will throw an exception on failure
         session = create_test_session()
         api = arlulacore.ArlulaAPI(session)
-        response = api.archiveAPI().order(arlulacore.OrderRequest(os.getenv("API_ORDERING_ID"), os.getenv("API_ORDER_LICENSE_HREF"), os.getenv("API_ORDER_BUNDLE_KEY")))
+        response = api.archiveAPI().order(arlulacore.OrderRequest(os.getenv("API_ORDERING_ID"), os.getenv("API_ORDER_LICENSE_HREF"), os.getenv("API_ORDER_BUNDLE_KEY"), team=os.getenv("API_TEAM_ID")))

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -86,12 +86,51 @@ class TestSearchRequest(unittest.TestCase):
             }
         )
 
-    def test_search(self):
+    def test_search_point(self):
         session = create_test_session()
         api = arlulacore.ArlulaAPI(session)
         result = api.archiveAPI().search(
             arlulacore.SearchRequest(date(2020, 1, 1), 100)
             .set_point_of_interest(-33, 151)
+            .set_end(date(2020, 2, 1))
+        )
+                
+        self.assertTrue(
+            len(result.results) > 0
+        )
+
+    def test_search_aoi(self):
+        session = create_test_session()
+        api = arlulacore.ArlulaAPI(session)
+        result = api.archiveAPI().search(
+            arlulacore.SearchRequest(date(2020, 1, 1), 100)
+            .set_area_of_interest(-33, -33.1, 150.1, 150)
+            .set_end(date(2020, 2, 1))
+        )
+                
+        self.assertTrue(
+            len(result.results) > 0
+        )
+
+    def test_search_polygon_wkt(self):
+        session = create_test_session()
+        api = arlulacore.ArlulaAPI(session)
+        result = api.archiveAPI().search(
+            arlulacore.SearchRequest(date(2020, 1, 1), 100)
+            .set_polygon("POLYGON((151.17454501612775 -33.90059831814348,151.16355868800275 -33.91769420996655,151.18724795802228 -33.93549878391787,151.19531604273908 -33.90700967940383,151.19359942896955 -33.89247656841645,151.17454501612775 -33.90059831814348))")
+            .set_end(date(2020, 2, 1))
+        )
+                
+        self.assertTrue(
+            len(result.results) > 0
+        )
+    
+    def test_search_polygon_array(self):
+        session = create_test_session()
+        api = arlulacore.ArlulaAPI(session)
+        result = api.archiveAPI().search(
+            arlulacore.SearchRequest(date(2020, 1, 1), 100)
+            .set_polygon([[[151.17592271889822,-33.90012296148858],[151.18776360157415,-33.94086373059308],[151.22992869598534,-33.938946954784306],[151.25823129360515,-33.91546294929382],[151.25736488755598,-33.88765718887135],[151.2085573467637,-33.87902597130201],[151.17592271889822,-33.90012296148858]]])
             .set_end(date(2020, 2, 1))
         )
                 

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -17,14 +17,12 @@ class TestOrders(unittest.TestCase):
         api = arlulacore.ArlulaAPI(session)
         response = api.ordersAPI().get(os.getenv("API_ORDER_ID"))
     
-
-
     def test_order_resource_as_file(self):
         session = create_test_session()
         api = arlulacore.ArlulaAPI(session)
         with tempfile.TemporaryDirectory() as temp_dir:
             filepath = os.path.join(temp_dir, "temp")
-            api.ordersAPI().get_resource_as_file(os.getenv("API_RESOURCE_ID"), "temp").close()
+            api.ordersAPI().get_resource_as_file(os.getenv("API_RESOURCE_ID"), filepath).close()
             self.assertTrue(os.path.getsize(filepath) > 0)
                 
     def test_order_resource_directory(self):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 import arlulacore
@@ -16,13 +17,22 @@ class TestOrders(unittest.TestCase):
         api = arlulacore.ArlulaAPI(session)
         response = api.ordersAPI().get(os.getenv("API_ORDER_ID"))
     
+
+
     def test_order_resource_as_file(self):
         session = create_test_session()
         api = arlulacore.ArlulaAPI(session)
-
-        with api.ordersAPI().get_resource_as_file(os.getenv("API_RESOURCE_ID"), "temp") as f:
-            pass
-        os.remove("temp")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filepath = os.path.join(temp_dir, "temp")
+            api.ordersAPI().get_resource_as_file(os.getenv("API_RESOURCE_ID"), "temp").close()
+            self.assertTrue(os.path.getsize(filepath) > 0)
+                
+    def test_order_resource_directory(self):
+        session = create_test_session()
+        api = arlulacore.ArlulaAPI(session)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            api.ordersAPI().get_resource_as_file(os.getenv("API_RESOURCE_ID"), suppress=True, directory=temp_dir).close()
+            self.assertTrue(len(os.listdir(temp_dir)) == 1)
 
     def test_order_resource_as_memory(self):
         session = create_test_session()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,22 @@
+
+import unittest
+import os
+
+class TestEnv(unittest.TestCase):
+    '''
+        Test the environment is setup correctly.
+    '''
+    def test_host(self):
+        self.assertNotEqual(os.getenv("API_HOST"), None)
+    def test_key(self):
+        self.assertNotEqual(os.getenv("API_KEY"), None)
+    def test_secret(self):
+        self.assertNotEqual(os.getenv("API_SECRET"), None)
+    def test_order_license_href(self):
+        self.assertNotEqual(os.getenv("API_ORDER_LICENSE_HREF"), None)
+    def test_order_bundle_key(self):
+        self.assertNotEqual(os.getenv("API_ORDER_BUNDLE_KEY"), None)
+    def test_ordering_id(self):
+        self.assertNotEqual(os.getenv("API_ORDERING_ID"), None)
+    def test_resource_id(self):
+        self.assertNotEqual(os.getenv("API_RESOURCE_ID"), None)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -20,3 +20,5 @@ class TestEnv(unittest.TestCase):
         self.assertNotEqual(os.getenv("API_ORDERING_ID"), None)
     def test_resource_id(self):
         self.assertNotEqual(os.getenv("API_RESOURCE_ID"), None)
+    def test_team_id(self):
+        self.assertNotEqual(os.getenv("API_TEAM_ID"), None)


### PR DESCRIPTION
Update 3.0.3 focusses on code quality improvements, the Arlula API 2023-01 update, and removal of backwards compatibility for 2021-09.
- Adds the support for WKT and list polygons on search.
- Adds dict and string methods for all classes.
- Updates .gitignore to a more extensive python-based template.
- Fixes a KeyError when resources on a DetailedOrderResult could not be found.
- Removes legacy support for Arlula API version 2021-09.
- Adds a TestEnv unittest file to ensure the test environment variables are setup correctly.
- Reworks how exceptions are handled, they will now give more relevant error messages.